### PR TITLE
fix NonExistentTimeError when dst change skips hour

### DIFF
--- a/fhnw_ds_hs2019_weatherstation_api/fhnw_ds_hs2019_weatherstation_api/data_import.py
+++ b/fhnw_ds_hs2019_weatherstation_api/fhnw_ds_hs2019_weatherstation_api/data_import.py
@@ -118,7 +118,7 @@ def __get_data_of_day(day, station):
 def __define_types(data, date_format):
     data['timestamp_cet'] = pd.to_datetime(data['timestamp_cet'], format=date_format)
     if not data.empty and data['timestamp_cet'].iloc[0].tzinfo is None:
-        data['timestamp_cet'] = data['timestamp_cet'].dt.tz_localize('Europe/Zurich', ambiguous=True).dt.tz_convert('UTC')
+        data['timestamp_cet'] = data['timestamp_cet'].dt.tz_localize('Europe/Zurich', ambiguous=True, nonexistent='shift_forward').dt.tz_convert('UTC')
     data.set_index('timestamp_cet', inplace=True)
     
     for column in data.columns[0:]:

--- a/fhnw_ds_hs2019_weatherstation_api/setup.py
+++ b/fhnw_ds_hs2019_weatherstation_api/setup.py
@@ -14,7 +14,7 @@ setup(name='fhnw_ds_hs2019_weatherstation_api',
       license='MIT',
       packages=['fhnw_ds_hs2019_weatherstation_api'],
       install_requires=[
-          'pandas<0.24',
+          'pandas',
           'influxdb',
           'requests',
           'tzlocal',


### PR DESCRIPTION
This PR will update pandas, since it requires the "nonexistent" option of tz_localize.

I couldn't reproduce the error mentioned in https://github.com/markif/WeatherStation_HS2019/commit/c4add2ee40745b86db064d6dc5ae9c316984cf19 after adding the other PRs to my code.

This may add Python 3.8 compatibility.